### PR TITLE
[Backend][pipe] read FIFO bug

### DIFF
--- a/backends/pipe/pipe_communication.cpp
+++ b/backends/pipe/pipe_communication.cpp
@@ -66,17 +66,32 @@ bool PipeCommunication::w_fifo(const int fd, const std::string& msg, std::mutex&
 }
 
 /* r_fifo
- * behavior: open fifo -> read fifo to msg -> return msg 
+ * behavior: open fifo -> read fifo to tmp_buf -> append to rbuf -> split by newline -> return one line from rbuf
  * note: no lock is needed for reads.
  */
-std::optional<std::string> PipeCommunication::r_fifo(const int fd) {
+std::optional<std::string> PipeCommunication::r_fifo(const int fd, std::string& rbuf) {
     if(!alive_) return std::nullopt;
-    char buf[1024];
 
-    ssize_t n = read(fd, buf, sizeof(buf));
+    auto getline_from_rbuf = [&](std::string& line) -> bool {
+        auto pos = rbuf.find('\n');
+        if(pos == std::string::npos) return false;
+        line = rbuf.substr(0, pos);
+        rbuf.erase(0, pos+1);
+        return true;
+    };
+
+    std::string msg;
+    if(getline_from_rbuf(msg)) return msg;
+
+    char tmp_buf[1024];
+    ssize_t n = read(fd, tmp_buf, sizeof(tmp_buf));
     if(n <= 0) return std::nullopt;
 
-    return std::string(buf, n);
+    rbuf.append(tmp_buf, n);
+
+    if(getline_from_rbuf(msg)) return msg;
+
+    return std::nullopt;
 }
 
 // public methods impl
@@ -90,8 +105,9 @@ bool PipeCommunication::initialize(int num_slots) {
     p2s_fd_.resize(num_slots_);
     s2p_fd_.resize(num_slots_);
     p2s_mutex_.resize(num_slots_);
-    p2s_mutex_.resize(num_slots_);
     s2p_mutex_.resize(num_slots_);
+    p2s_rbuf_.resize(num_slots_);
+    s2p_rbuf_.resize(num_slots_);
 
     // loop through entries and instantiate objects
     for(int i=0; i<num_slots_; ++i) {
@@ -157,7 +173,7 @@ bool PipeCommunication::send_to_player(int slot, const std::string& msg) {
 
 std::optional<std::string> PipeCommunication::recv_from_player(int slot) {
     if(!SlotValid(slot, num_slots_)) return std::nullopt;
-    return r_fifo(p2s_fd_[slot]);
+    return r_fifo(p2s_fd_[slot], p2s_rbuf_[slot]);
 }
 
 bool PipeCommunication::send_to_server(int slot, const std::string& msg) {
@@ -167,7 +183,7 @@ bool PipeCommunication::send_to_server(int slot, const std::string& msg) {
 
 std::optional<std::string> PipeCommunication::recv_from_server(int slot) {
     if(!SlotValid(slot, num_slots_)) return std::nullopt;
-    return r_fifo(s2p_fd_[slot]);
+    return r_fifo(s2p_fd_[slot], s2p_rbuf_[slot]);
 }
 
 } // namspace werewolf

--- a/backends/pipe/pipe_communication.h
+++ b/backends/pipe/pipe_communication.h
@@ -33,10 +33,12 @@ private:
     std::vector<int> s2p_fd_;
     std::vector<std::unique_ptr<std::mutex>> p2s_mutex_;
     std::vector<std::unique_ptr<std::mutex>> s2p_mutex_;
+    std::vector<std::string> p2s_rbuf_;
+    std::vector<std::string> s2p_rbuf_;
 
     // fifo operations
     bool w_fifo(const int fd, const std::string& msg, std::mutex& mu);
-    std::optional<std::string> r_fifo(const int fd);
+    std::optional<std::string> r_fifo(const int fd, std::string& rbuf);
 
 };
 

--- a/tests/pipe/test_pipe.cpp
+++ b/tests/pipe/test_pipe.cpp
@@ -33,7 +33,7 @@ TEST(PipeCommunicationTest, P2S) {
     }
 
     ASSERT_TRUE(msg.has_value());
-    EXPECT_EQ(msg.value(), "hello\n");
+    EXPECT_EQ(msg.value(), "hello");
 
     player.join();
     comm->shutdown();
@@ -58,7 +58,42 @@ TEST(PipeCommunicationTest, S2P) {
     }
 
     ASSERT_TRUE(msg.has_value());
-    EXPECT_EQ(msg.value(), "vote\n");
+    EXPECT_EQ(msg.value(), "vote");
+
+    server.join();
+    comm->shutdown();
+}
+
+// multiple messages with new line
+TEST(PipeCommunicationTest, MultiMsg) {
+    testutils::TempDir tmp;
+    auto comm = werewolf::make_pipe_communication(tmp.path(), true);
+    ASSERT_TRUE(comm->initialize(1));
+
+    std::thread server([&](){
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        comm->send_to_player(0, "hello2");
+        comm->send_to_player(0, "hello1");
+        comm->send_to_player(0, "hello0");
+    });
+
+    std::optional<std::string> msg;
+    for(int i=0;i<10;i++) {
+        msg = comm->recv_from_server(0);
+        if(msg) break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+
+    ASSERT_TRUE(msg.has_value());
+    EXPECT_EQ(msg.value(), "hello2");
+
+    msg = comm->recv_from_server(0);
+    ASSERT_TRUE(msg.has_value());
+    EXPECT_EQ(msg.value(), "hello1");
+
+    msg = comm->recv_from_server(0);
+    ASSERT_TRUE(msg.has_value());
+    EXPECT_EQ(msg.value(), "hello0");
 
     server.join();
     comm->shutdown();


### PR DESCRIPTION
## Root Cause

There was a misunderstanding of FIFO blocking semantics. 

Here is a breakdown of POSIX FIFO behavior for clarity:



1. FIFO open() Behavior



Call | Condition | Behavior 
--- | --- | --- 
open(O_WRONLY) | No active reader | Blocks 
open(O_RDONLY) | No active writer | Blocks 
open(O_RDWR) | Always OK | Never blocks 



2. FIFO read() Behavior



| Condition | read() Behavior |
| :--- | :--- |
| Pipe buffer has data | Returns the bytes read |
| Pipe buffer is empty | Blocks (until data arrives) |
| No writers left (pipe closed) | Returns 0 (EOF) |



While opening a pipe with `O_RDWR` guarantees that open() will never block, read() will still block if the pipe buffer is empty.



Currently, `r_fifo` unconditionally invokes the OS read() system call before parsing its internal buffer. 

Because the first `recv_from_server` greedily reads all available data (e.g., "hello0\nhello1\n"), the OS pipe becomes empty. 

The second `recv_from_server` then hits the OS read() on that empty pipe and blocks indefinitely.


## Fix
Reordered the read logic to prevent unnecessary OS-level reads:



Check the internal buffer first: Search for a complete message (delimited by \n) in the existing string buffer.

Conditional read: Only invoke the blocking OS read() system call if the internal buffer does not already contain a complete, unparsed message.

This PR fixes #4 