### PR TITLE
[Game] ScopeGuard for communication object in Game::run

### DIFF
--- a/docs/game.md
+++ b/docs/game.md
@@ -1,0 +1,8 @@
+## Werewolf Game logic implementation
+
+Destroy(/scope exit) Invaiants:
+- `running_` state being false.
+- if `comm_` is initialized, shutdown, otherwise, no-op.
+- flush every occupied resources (log files).
+
+Tests: tests/game/test_game.cpp

--- a/include/werewolf/game.h
+++ b/include/werewolf/game.h
@@ -22,6 +22,17 @@ public:
     void request_stop();
 
 private:
+    // nested scope guard
+    // This guard ensures proper shutdown when un-expected or abnormal returns before scope ends.
+    struct CleanupGuard {
+        Game& game;
+        bool is_initialized = false;
+
+        CleanupGuard(Game& game);
+        ~CleanupGuard();
+    };
+
+    // members
     std::unique_ptr<ICommunication> comm_;
     GameConfig cfg_;
     std::atomic<bool> running_{false};
@@ -31,6 +42,7 @@ private:
     std::mutex log_mutex_;
 
     void log(const std::string& msg, bool to_stdout=true, bool to_game_log=true, bool to_moderator_log=true);
+
 };
 
 } // namespace werewolf

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6,12 +6,30 @@
 
 namespace werewolf {
 
+// cleanup scope guard
+Game::CleanupGuard::CleanupGuard(Game& game): game(game) {}  
+
+Game::CleanupGuard::~CleanupGuard() {
+    game.running_.store(false);
+    if(is_initialized && game.comm_) {
+        game.comm_->shutdown();
+    }
+    if(game.game_log_.is_open()) {
+        game.game_log_.flush();
+    }
+    if(game.moderator_log_.is_open()) {
+        game.moderator_log_.flush();
+    }
+}
+
+// ctor & dtor
 Game::Game(std::unique_ptr<ICommunication> comm, GameConfig cfg): comm_(std::move(comm)), cfg_(std::move(cfg)) {}
 
 Game::~Game() {
     request_stop();
 }
 
+// methods
 void Game::request_stop() {
     running_.store(false);
 }
@@ -39,6 +57,9 @@ void Game::log(const std::string& msg, bool to_stdout, bool to_game_log, bool to
 void Game::run() {
     running_.store(true);
 
+    // handle game state and communication object lifecycle automatically
+    CleanupGuard scope_guard(*this);
+
     game_log_.open(cfg_.game_log, std::ios::app);
     moderator_log_.open(cfg_.moderator_log, std::ios::app);
 
@@ -53,12 +74,11 @@ void Game::run() {
         running_.store(false);
         return;
     }
+    scope_guard.is_initialized = true;
 
     log(">>> Werewolf game starting <<<");
 
-    comm_->shutdown();
     log(">>> Werewolf game ended <<<");
-    running_.store(false);
 }
 
 } // namespace werewolf

--- a/tests/game/test_game.cpp
+++ b/tests/game/test_game.cpp
@@ -46,4 +46,14 @@ TEST(GameTest, RunReturnsWhenInitializeFails) {
     EXPECT_EQ(raw->shutdown_called, 0);
 }
 
+TEST(GameTest, RunWithNullCommunicationDoesNotCrash) {
+    GameConfig cfg;
+    testutils::TempDir game_log_tmp, moderator_log_tmp;
+    cfg.game_log = game_log_tmp.path() + "/game.log";
+    cfg.moderator_log = moderator_log_tmp.path() + "/moderator.log";
+
+    Game game(nullptr, cfg);
+    EXPECT_NO_THROW(game.run());
+}
+
 } // namespace werewolf::test


### PR DESCRIPTION
What's done in this PR:
- Add scope guard to automatic handle communication object lifecycle in `Game::run`
- Add basic game documentation
- Expand test_game.cpp coverage.