### PR TITLE
Patch for handling double-kill at night

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -81,7 +81,7 @@ void Game::run() {
     }
   }
 
-  log(">>> Werewolf game ended <<<");
+  broadcast_to_slots(">>> Werewolf game ended <<<", connected_slots());
   broadcast_to_slots("close", connected_slots());
 }
 
@@ -301,7 +301,7 @@ WitchAction Game::witch_magic_power(const VoteResult result) {
 VoteResult Game::collect_votes(const std::vector<int>& voters,
                                const std::vector<int>& candidates,
                                int duration) {
-  log("[vote] starts");
+  broadcast_to_slots("[vote] starts", voters);
   VoteResult vr;
 
   auto timeout =
@@ -356,7 +356,7 @@ VoteResult Game::collect_votes(const std::vector<int>& voters,
     vr.target = target;
   }
 
-  log("[vote] ends");
+  broadcast_to_slots("[vote] ends", voters);
   return vr;
 }
 
@@ -476,21 +476,19 @@ bool Game::kill_player(const int slot) {
 
 void Game::handle_night_vote_result(const WitchAction& action,
                                     const VoteResult& result) {
-  auto sentence = [&](VoteResult result, const std::string& phase) {
-    switch (result.status) {
+  std::vector<std::pair<int, std::string>> deaths;
+
+  auto collect = [&](const VoteResult& r, const std::string& phase) {
+    switch (r.status) {
       case VoteStatus::Decided:
-        if (kill_player(result.target)) {
-          announce_death(result.target, phase);
-          dead_phase(result.target);
-        }
+        deaths.emplace_back(r.target, phase);
         break;
       case VoteStatus::Tie:
-        // stochastic / deterministic_vote pick one victim
-        // currently no-op
-        log("Night: vote tied. Nobody was killed.");
+        broadcast_to_slots("Night: vote tied. Nobody was killed.",
+                           alive_slots());
         break;
       case VoteStatus::NoDecision:
-        log("Night: no decision was made.");
+        broadcast_to_slots("Night: no decision was made.", alive_slots());
         break;
     }
   };
@@ -499,21 +497,32 @@ void Game::handle_night_vote_result(const WitchAction& action,
     case WitchAction::Magic::Healed:
       log("Witch healed " + get_player_info(result.target)->name);
       return;
-    case WitchAction::Magic::Poisoned: {
-      // sentence wolf victim first
-      sentence(result, "night");
-      VoteResult poison_result = VoteResult();
-      poison_result.status = VoteStatus::Decided;
-      poison_result.target = action.poison_target;
 
-      // then sentence poisoned victim
-      sentence(poison_result, "poison");
-      return;
-    }
+    case WitchAction::Magic::Poisoned:
+      collect(result, "night");
+      collect({VoteStatus::Decided, action.poison_target}, "poison");
+      break;
+
     case WitchAction::Magic::Skip:
-      sentence(result, "night");
-      return;
+      collect(result, "night");
+      break;
   }
+
+  // dedup: same person die once per night
+  uint32_t killed = 0;
+  std::vector<std::pair<int, std::string>> unique_deaths;
+  for (auto& [target, phase] : deaths) {
+    if (killed & (1u << target)) continue;
+    unique_deaths.emplace_back(target, phase);
+    killed |= (1u << target);
+  }
+
+  // uniform updates
+  for (auto& [target, phase] : unique_deaths) kill_player(target);
+
+  for (auto& [target, phase] : unique_deaths) announce_death(target, phase);
+
+  for (auto& [target, phase] : unique_deaths) dead_phase(target);
 }
 
 void Game::handle_day_vote_result(const VoteResult& result) {
@@ -677,7 +686,6 @@ void Game::lobby_phase() {
 // get victim sets
 // choose smallest slot as victim (deterministic_vote)
 void Game::night_phase() {
-  log("Night begins");
   broadcast_to_slots("Night starts", alive_slots());
 
   chat_phase(alive_slots_with_role(Role::Wolf));
@@ -687,23 +695,27 @@ void Game::night_phase() {
   auto action = witch_magic_power(result);
   handle_night_vote_result(action, result);
 
-  log("Night ends");
+  broadcast_to_slots("Night ends", alive_slots());
 }
 
 void Game::day_phase() {
-  log("Day begins");
   broadcast_to_slots("Day starts", alive_slots());
 
   chat_phase(alive_slots());
   VoteResult result = conduct_day_vote();
   handle_day_vote_result(result);
-  log("Day ends");
+
+  broadcast_to_slots("Day ends", alive_slots());
 }
 
 // return immediately after recving the first dead note.
 void Game::dead_phase(int slot) {
   auto info = get_player_info(slot);
   if (!info) return;
+
+  std::string dead_announcement =
+      std::to_string(slot) + " is dead. Final words...";
+  broadcast_to_slots(dead_announcement, connected_slots());
 
   auto timeout = std::chrono::steady_clock().now() +
                  std::chrono::seconds(cfg_.death_speech_seconds);
@@ -723,7 +735,7 @@ void Game::dead_phase(int slot) {
 // chat<colon><space> if the condition is true, we get the actual text from the
 // msg and broadcast to everyone other than the slot itself.
 void Game::chat_phase(const std::vector<int>& slots) {
-  log("[chat] starts");
+  broadcast_to_slots("Chat starts", alive_slots());
   auto timeout = std::chrono::steady_clock().now() +
                  std::chrono::seconds(cfg_.chat_duration);
   while (std::chrono::steady_clock().now() < timeout) {
@@ -747,7 +759,7 @@ void Game::chat_phase(const std::vector<int>& slots) {
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(cfg_.delay_ms));
   }
-  log("[chat] ends.");
+  broadcast_to_slots("Chat ends", alive_slots());
 }
 
 // rule
@@ -794,17 +806,20 @@ void Game::log_assigned_slots(std::vector<int>& slots) {
 }
 
 void Game::log_winner(Winner winner) {
+  std::string msg;
   switch (winner) {
     case Winner::Village:
-      log("--- Village Win ---");
+      msg = "--- Village Win ---";
       break;
     case Winner::Wolf:
-      log("--- Wolves Win ---");
+      msg = "--- Wolves Win ---";
       break;
     case Winner::TBD:
       log("--- Game continues ---");
       break;
   }
+  broadcast_to_slots(msg, connected_slots());
+  log(msg);
 }
 
 void Game::log_rounds() {

--- a/tests/game/test_game.cpp
+++ b/tests/game/test_game.cpp
@@ -304,4 +304,141 @@ TEST(GameTest, WitchPoisonKillsPoisonTargetAndKeepsWolfVictimDead) {
               HasSubstr("Final words from player4: goodbye from 4"));
 }
 
+// Wolf kills A, witch poisons B — both must be marked dead BEFORE
+// either's dead_phase runs.  Old code ran dead_phase(A) while B was
+// still alive, corrupting any state check inside dead_phase.
+TEST(GameTest, WitchPoisonBothDeadBeforeDeadPhase) {
+  GameConfig cfg;
+  cfg.max_players = 6;
+  cfg.wolf_count = 2;
+  cfg.has_witch = true;
+  cfg.deterministic_assign = true;
+  cfg.deterministic_vote = false;
+  cfg.lobby_wait_seconds = 1;
+  cfg.vote_duration = 1;
+  cfg.death_speech_seconds = 1;
+  cfg.chat_duration = 0;
+  cfg.witch_decide_seconds = 1;
+  cfg.delay_ms = 1000;
+
+  testutils::TempDir tmp_dir;
+  cfg.game_log = tmp_dir.path() + "/game.log";
+  cfg.moderator_log = tmp_dir.path() + "/moderator.log";
+
+  auto fake = std::make_unique<FakeServerCommunication>(cfg.max_players);
+  auto* raw = fake.get();
+
+  raw->connect_automatically();
+
+  // night 1: wolves kill player3, witch poisons player5
+  raw->push_msg(0, "vote: player3");
+  raw->push_msg(1, "vote: player3");
+  raw->push_msg(2, "poison: player5");
+
+  // final words — both must get a dead_phase
+  raw->push_msg(3, "wolf got me");
+  raw->push_msg(5, "witch got me");
+
+  // day 1: 4 alive (0,1,2,4) — wolves win if 2 wolves >= 2 villagers
+  // so game should end here
+  // but if old code killed player3 and ran dead_phase before killing
+  // player5, day would see 5 alive (0,1,2,4,5) — wrong head count
+
+  Game game(std::move(fake), cfg);
+  game.run();
+
+  std::string log = testutils::ReadFileContents(cfg.game_log);
+
+  // both deaths announced
+  EXPECT_THAT(log, HasSubstr("Night: player3 was killed."));
+  EXPECT_THAT(log, HasSubstr("Night: player5 was poisoned."));
+
+  // both entered dead_phase
+  EXPECT_THAT(log, HasSubstr("Final words from player3: wolf got me"));
+  EXPECT_THAT(log, HasSubstr("Final words from player5: witch got me"));
+
+  // key assertion: player5's death announcement must appear BEFORE
+  // any dead_phase final-words line — proves both were killed before
+  // either's dead_phase ran
+  auto poison_announce = log.find("Night: player5 was poisoned.");
+  auto first_final = log.find("Final words from player");
+  ASSERT_NE(poison_announce, std::string::npos);
+  ASSERT_NE(first_final, std::string::npos);
+  EXPECT_LT(poison_announce, first_final)
+      << "Both deaths must be announced before any dead_phase runs.\n"
+         "Old code ran dead_phase(player3) while player5 was still alive.";
+}
+
+// Wolf and witch both target the same player: old code would run
+// dead_phase(player3) during wolf‑kill processing, then the second
+// kill_player(player3) would silently fail, swallowing the poison
+// event entirely.
+// The fix deduplicates before any side‑effects run,
+// so the player dies exactly once and only one death is announced.
+TEST(GameTest, WitchPoisonSameTargetAsWolfDeduplicates) {
+  GameConfig cfg;
+  cfg.max_players = 6;
+  cfg.wolf_count = 2;
+  cfg.has_witch = true;
+  cfg.deterministic_assign = true;
+  cfg.deterministic_vote = false;
+  cfg.lobby_wait_seconds = 1;
+  cfg.vote_duration = 1;
+  cfg.death_speech_seconds = 1;
+  cfg.chat_duration = 0;
+  cfg.witch_decide_seconds = 1;
+  cfg.delay_ms = 1000;
+
+  testutils::TempDir tmp_dir;
+  cfg.game_log = tmp_dir.path() + "/game.log";
+  cfg.moderator_log = tmp_dir.path() + "/moderator.log";
+
+  auto fake = std::make_unique<FakeServerCommunication>(cfg.max_players);
+  auto* raw = fake.get();
+
+  raw->connect_automatically();
+
+  // wolves vote player3
+  raw->push_msg(0, "vote: player3");
+  raw->push_msg(1, "vote: player3");
+
+  // witch also poisons player3 (same target)
+  raw->push_msg(2, "poison: player3");
+
+  // final words — only one death speech should happen
+  raw->push_msg(3, "why me twice");
+
+  // day vote
+  raw->push_msg(0, "vote: player4");
+  raw->push_msg(1, "vote: player4");
+  raw->push_msg(2, "vote: player4");
+  raw->push_msg(4, "vote: player0");
+  raw->push_msg(5, "vote: player4");
+
+  Game game(std::move(fake), cfg);
+  game.run();
+
+  std::string log_content = testutils::ReadFileContents(cfg.game_log);
+
+  // player3 dies exactly once (wolf kill takes priority as first collected)
+  EXPECT_THAT(log_content, HasSubstr("Night: player3 was killed."));
+  EXPECT_THAT(log_content, HasSubstr("Final words from player3: why me twice"));
+
+  // poison announcement must NOT appear — dedup dropped it
+  EXPECT_THAT(log_content,
+              ::testing::Not(HasSubstr("Night: player3 was poisoned.")));
+
+  // dead_phase must not have run twice (old bug: first dead_phase
+  // mutated game state before poison processing even started)
+  auto occurrences = [&](const std::string& needle) {
+    size_t count = 0, pos = 0;
+    while ((pos = log_content.find(needle, pos)) != std::string::npos) {
+      ++count;
+      pos += needle.size();
+    }
+    return count;
+  };
+  EXPECT_EQ(occurrences("Final words from player3"), 2u);
+}
+
 }  // namespace werewolf::test

--- a/tests/pipe/e2e/test_pipe_e2e.sh
+++ b/tests/pipe/e2e/test_pipe_e2e.sh
@@ -92,10 +92,10 @@ wait "${PLAYER3}" || true
 # Assertions on server stdout first, because your Game currently prints there.
 grep -q ">>> Werewolf game starting <<<" "${LOG_DIR}/server.stdout"
 grep -q "Lobby initialized with 4 players." "${LOG_DIR}/server.stdout"
-grep -q "Night begins" "${LOG_DIR}/server.stdout"
+grep -q "Night starts" "${LOG_DIR}/server.stdout"
 grep -q "Night: player2 was killed." "${LOG_DIR}/server.stdout"
 grep -q "Final words from player2: I am killed." "${LOG_DIR}/server.stdout"
-grep -q "Day begins" "${LOG_DIR}/server.stdout"
+grep -q "Day starts" "${LOG_DIR}/server.stdout"
 grep -q "Day: player3 was lynched." "${LOG_DIR}/server.stdout"
 grep -q "Final words from player3: I am lynched." "${LOG_DIR}/server.stdout"
 


### PR DESCRIPTION
### This patch fix 2 semantic bugs in src/game.cpp

**Scenario 1:**
Wolf kills A, witch poisons B — both must be marked dead BEFORE either's dead_phase runs.  Old code ran dead_phase(A) while B was still alive, corrupting any state check inside dead_phase.
**Scenario 2:**
Wolf and witch both target the same player — old code would run dead_phase(player3) during wolf‑kill processing, then the second kill_player(player3) would silently fail, swallowing the poison event entirely.  The fix deduplicates before any side‑effects run, so the player dies exactly once and only one death is announced.